### PR TITLE
feat(chat): add typing skeleton and disable send button when input is…

### DIFF
--- a/src/shared/components/ChatInput.tsx
+++ b/src/shared/components/ChatInput.tsx
@@ -17,15 +17,20 @@ export default function ChatInput({ onSend }: ChatInputProps) {
 
     return (
         <form onSubmit={handleSubmit} className="p-4 border-t border-zinc-700 bg-[#1e1e20] flex gap-2">
-            <input 
+            <input
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 placeholder="Ask anything..."
                 className="flex-1 p-3 rounded-md bg-[#2c2c2f] text-white placeholder-gray-400 border border-zinc-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
-            <button type="submit" className="px-4 py-2 text-black transition cursor-pointer rounded-full bg-white text-black hover:bg-gray-200 transition shadow-md disabled:opacity-50">
+            <button
+                type="submit"
+                disabled={!input.trim()}
+                className="px-4 py-2 text-black transition cursor-pointer rounded-full bg-white hover:bg-gray-200 shadow-md disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-gray-300"
+            >
                 <ArrowUpIcon className="w-5 h-5" />
             </button>
+
         </form>
     )
 }

--- a/src/shared/components/MessageList.tsx
+++ b/src/shared/components/MessageList.tsx
@@ -21,7 +21,7 @@ export default function MessageList({ messages, isLoading }: MessageListProps) {
         <div className="flex-1 overflow-y-auto px-4 space-y-4 custom-scrollbar">
             {isEmpty ? (
                 <div className="flex flex-col items-center justify-center h-full text-center text-gray-500">
-                    <Image 
+                    <Image
                         src="/favicon.png"
                         alt="Mobivisor Logo"
                         width={100}
@@ -39,7 +39,27 @@ export default function MessageList({ messages, isLoading }: MessageListProps) {
                         {messages.map((message, index) => (
                             <Message key={index} role={message.role} content={message.content} sources={message.sources} />
                         ))}
-                        {isLoading && <p className="text-gray-400 text-sm italic">Thinking...</p>}
+                        {isLoading && (
+
+                            <div className="flex justify-start mb-3">
+                                <div className="mr-2 flex-shrink-0">
+                                    <Image
+                                        src="/favicon.png"
+                                        alt="System"
+                                        width={32}
+                                        height={32}
+                                        className="rounded-full"
+                                    />
+                                </div>
+
+                                <div className="flex flex-col gap-2 bg-[#2a2a2d] px-4 py-3 rounded-lg max-w-xl animate-pulse w-full">
+                                    <div className="h-3 rounded bg-gray-700 w-[90%]" />
+                                    <div className="h-3 rounded bg-gray-700 w-[80%]" />
+                                    <div className="h-3 rounded bg-gray-700 w-[65%]" />
+                                </div>
+                            </div>
+                        )}
+
                         <div ref={bottomRef} />
                     </div>
                 </>

--- a/src/shared/components/MessageList.tsx
+++ b/src/shared/components/MessageList.tsx
@@ -40,7 +40,6 @@ export default function MessageList({ messages, isLoading }: MessageListProps) {
                             <Message key={index} role={message.role} content={message.content} sources={message.sources} />
                         ))}
                         {isLoading && (
-
                             <div className="flex justify-start mb-3">
                                 <div className="mr-2 flex-shrink-0">
                                     <Image


### PR DESCRIPTION
… empty

- Replaced "Thinking..." text with a skeleton-style animated message bubble using logo and grey blocks to mimic ChatGPT-like typing feedback.
- Disabled the send button when the input field is empty or whitespace-only.
- Improved UI feedback with opacity and cursor changes on the disabled button.